### PR TITLE
rename scripts file, test report, test stake, scaffolding

### DIFF
--- a/example_mock.py
+++ b/example_mock.py
@@ -3,7 +3,7 @@ from time import time, sleep
 from algosdk import account, encoding
 from algosdk.logic import get_application_address
 from pyteal import Txn
-from scripts.deploy import Scripts
+from scripts.scripts import Scripts
 from utils.util import (
     getBalances,
     getAppGlobalState,

--- a/scripts/scripts.py
+++ b/scripts/scripts.py
@@ -68,7 +68,7 @@ class Scripts:
         """
         approval, clear = self.get_contracts(self.client)
 
-        globalSchema = transaction.StateSchema(num_uints=7, num_byte_slices=5)
+        globalSchema = transaction.StateSchema(num_uints=7, num_byte_slices=6)
         localSchema = transaction.StateSchema(num_uints=0, num_byte_slices=0)
 
         app_args = [
@@ -142,13 +142,13 @@ class Scripts:
 
         waitForTransaction(self.client, stakeInTx.get_txid())
 
-    def report(self,value: str):
-        value = value.encode('utf-8')
+    def report(self,query_id: bytes, value: bytes):
+        # value = value.encode('utf-8')
 
         submitValueTxn = transaction.ApplicationNoOpTxn(
             sender=self.reporter.getAddress(),
             index=self.app_id,
-            app_args=[b'report',value],
+            app_args=[b'report',query_id, value],
             sp=self.client.suggested_params()
         )
 

--- a/tests/flex_test.py
+++ b/tests/flex_test.py
@@ -10,7 +10,7 @@ from algosdk import account, encoding
 from algosdk.logic import get_application_address
 
 from tellorflex.methods import create, stake, vote, report, withdraw
-from scripts.deploy import Scripts
+from scripts.scripts import Scripts
 from utils.helpers import _algod_client
 from utils.util import  getBalances, getAppGlobalState, getLastBlockTimestamp
 from utils.testing.resources import getTemporaryAccount, optInToAsset, createDummyAsset


### PR DESCRIPTION
- renamed deploy.py to scripts.py because it's more than just deployment scripting
- `report()` function test
- 'stake()` function test
- more tests scaffolded