### PR TITLE
overflow testing

### DIFF
--- a/src/contracts/methods.py
+++ b/src/contracts/methods.py
@@ -41,7 +41,6 @@ def create():
         [
             App.globalPut(tipper, Txn.sender()),
             # TODO assert application args length is correct
-            Assert(Txn.application_args.length() == Int(3)),
             App.globalPut(governance_address, Txn.application_args[0]),
             App.globalPut(query_id, Txn.application_args[1]),
             App.globalPut(query_data, Txn.application_args[2]),  # TODO perhaps parse from ipfs
@@ -49,7 +48,7 @@ def create():
             App.globalPut(reporter, Bytes("")),
             App.globalPut(staking_status, Int(0)),
             App.globalPut(num_reports, Int(0)),
-            App.globalPut(stake_amount, Int(100000)),  # 200 dollars of ALGO
+            App.globalPut(stake_amount, Int(200000)),  # 200 dollars of ALGO
             Approve(),
         ]
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,7 @@ def deployed_contract(accounts, client, scripts):
         b"query_id": query_id.encode("utf-8"),
         b"query_data": query_data.encode("utf-8"),
         b"num_reports": 0,
-        b"stake_amount": 100000,
+        b"stake_amount": 200000,
         b"staking_status": 0,
         b"reporter_address": b"",
         b"tipper": encoding.decode_address(accounts.tipper.getAddress()),

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -141,6 +141,13 @@ def test_withdraw_after_slashing(scripts, client, deployed_contract):
     with pytest.raises(AlgodHTTPError):
         scripts.withdraw()
 
+
 def test_overflow_in_create(scripts, client):
-    '''Contract deployment should revert if
-     bytes inputs are longer than 128 bytes'''
+    """Contract deployment should revert if
+    bytes inputs are longer than 128 bytes"""
+
+    too_long_query_id = "a" * 129
+    query_data = "my query_id is invalid because it is >128 bytes in length"
+
+    with pytest.raises(AlgodHTTPError):
+        scripts.deploy_tellor_flex(query_id=too_long_query_id, query_data=query_data)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -30,7 +30,7 @@ def test_report(client, scripts, accounts, deployed_contract):
 def test_stake(client, scripts, accounts, deployed_contract):
     """Test stake() method on contract"""
 
-    stake_amount = 100000
+    stake_amount = 200000
 
     reporter_algo_balance_before = client.account_info(accounts.reporter.getAddress()).get("amount")
     state = getAppGlobalState(client, deployed_contract.id)


### PR DESCRIPTION
Confirm that contract deployment reverts if the bytes slots are overflowed with >128 byte strings